### PR TITLE
fix: update CLI version to 0.7.0

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,7 @@ interface CliOptions {
   version?: boolean
 }
 
-const VERSION = '0.6.0'
+const VERSION = '0.7.0'
 
 const HELP_TEXT = `
 kaitai - Parse binary files using Kaitai Struct definitions


### PR DESCRIPTION
Updates the hardcoded VERSION constant in src/cli.ts to match package.json version 0.7.0