### PR TITLE
Release v0.7.1 - Fix CLI inclusion in published package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2025-10-02
+
+### Fixed
+- CLI executable now properly included in published npm package
+- Previous v0.7.0 was published from tag before CLI was fully merged
+
 ## [0.7.0] - 2025-10-02
 
 ### 🎉 CLI Utility - Command-Line Interface

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Runtime interpreter for Kaitai Struct binary format definitions in TypeScript",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Problem

v0.7.0 was published from the git tag before the CLI fix PR was merged, resulting in the CLI file not being included in the published npm package.

## Solution

This patch release (v0.7.1) includes the complete CLI implementation with the correct version.

## Changes
- Updated CHANGELOG.md with v0.7.1 entry
- Version bumped to 0.7.1
- CLI file (dist/cli.js) is now properly included

## Verification
```bash
npm pack --dry-run
# Shows dist/cli.js is included
```